### PR TITLE
changed the spatial query option for the get_results method

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tethysts" %}
-{% set version = "0.4.14" %}
+{% set version = "0.4.15" %}
 # {% set sha256 = "ae2cc83fb5a75e8dc3e1b2c2137deea412c8a4c7c9acca52bf4ec59de52a80c9" %}
 
 # sha256 is the prefered checksum -- you can get it for a file with:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tethysts" %}
-{% set version = "0.4.15" %}
+{% set version = "0.4.16" %}
 # {% set sha256 = "ae2cc83fb5a75e8dc3e1b2c2137deea412c8a4c7c9acca52bf4ec59de52a80c9" %}
 
 # sha256 is the prefered checksum -- you can get it for a file with:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 name = 'tethysts'
 main_package = 'tethysts'
 datasets = 'datasets/time_series'
-version = '0.4.15'
+version = '0.4.16'
 descrip = 'tethys time series S3 extraction'
 
 # The below code is for readthedocs. To have sphinx/readthedocs interact with

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 name = 'tethysts'
 main_package = 'tethysts'
 datasets = 'datasets/time_series'
-version = '0.4.14'
+version = '0.4.15'
 descrip = 'tethys time series S3 extraction'
 
 # The below code is for readthedocs. To have sphinx/readthedocs interact with

--- a/sphinx/source/usage_a.rst
+++ b/sphinx/source/usage_a.rst
@@ -138,7 +138,7 @@ The get_results method has many input options. Take a look at the reference page
 
 Unlike the previously returned objects, the results object (in this case) is an xarray Dataset. This xarray Dataset contains both the results (temperature) and all of the dataset metadata and station data. Other options include an xarray DataArray, dictionary, and JSON. If the results represent geospatially sparse data, then the results are indexed by geometry, height, and time. If the results represent gridded data, then the results are indexed by lat, lon, height, and time. The geometry dimension is a hexadecimal encoded Well-Known Binary (WKB) representation of the geometry. This was used to be flexible on the geometry type (i.e. points, lines, or polygons) and the WKB ensures that the geometry is stored accurately. This is a standard format by the Open Geospatial Consortium (OGC) and can be parsed by many programs including shapely, PostGIS, etc. Using WKB in a geometry dimension does not follow CF conventions. This was a trade off between flexibility, simplicity, and following standards. I picked flexibility and simplicity.
 
-Similar to the get_stations spatial query, the get_results method has a built-in nearest neighbour query if you omit the station_id and pass either geometry dict or a combination of latitude and longitude.
+In addition to the get_stations spatial queries, the get_results method has a built-in nearest neighbour query if you omit the station_id and pass either geometry dict or a combination of latitude and longitude. This is especially useful for gridded results when each station represents a large area rather than a single point.
 
 .. ipython:: python
 

--- a/tethysts/main.py
+++ b/tethysts/main.py
@@ -473,7 +473,6 @@ class Tethys(object):
                     geometry: dict = None,
                     lat: float = None,
                     lon: float = None,
-                    distance: float = None,
                     from_date: Union[str, pd.Timestamp, datetime] = None,
                     to_date: Union[str, pd.Timestamp, datetime] = None,
                     from_mod_date: Union[str, pd.Timestamp, datetime] = None,
@@ -496,13 +495,11 @@ class Tethys(object):
         station_ids : str, list of str, or None
             The station_ids of the associated station.
         geometry : dict or None
-            A geometry in GeoJSON format. Can be either a point or a polygon. If it's a point, then the method will perform a nearest neighbor query and return one station.
+            A point geometry in GeoJSON format. If it's a point, then the method will perform a nearest neighbor query and return one station.
         lat : float or None
-            Instead of using the geometry parameter, optionally use lat and lon for the spatial queries. Both lat and lon must be passed for the spatial queries and will override the geometry parameter. If only lat and lon are passed, then the method performs a nearest neighbor query.
+            Instead of using the geometry parameter, optionally use lat and lon for the nearest neighbor spatial query. Both lat and lon must be passed for the spatial query and will override the geometry parameter.
         lon : float or None
             See lat description.
-        distance : float or None
-            See lat description. This should be in decimal degrees not meters.
         from_date : str, Timestamp, datetime, or None
             The start date of the selection.
         to_date : str, Timestamp, datetime, or None
@@ -551,7 +548,7 @@ class Tethys(object):
             stn_ids = [station_ids]
         elif isinstance(station_ids, list):
             stn_ids = station_ids
-        elif ((geom_type in ['Point', 'Polygon']) or (isinstance(lat, float) and isinstance(lon, float))):
+        elif ((geom_type in ['Point']) or (isinstance(lat, float) and isinstance(lon, float))):
             ## Get all stations
             if dataset_id not in self._stations:
                 _ = self.get_stations(dataset_id)
@@ -559,9 +556,9 @@ class Tethys(object):
             stn_dict = self._stations[dataset_id]
 
             # Run the spatial query
-            stn_ids = spatial_query(stn_dict, geometry, lat, lon, distance)
+            stn_ids = spatial_query(stn_dict, geometry, lat, lon, None)
         else:
-            raise ValueError('A station_id, geometry or a combination of lat and lon must be passed.')
+            raise ValueError('A station_id, point geometry or a combination of lat and lon must be passed.')
 
         ## Get results chunks
         self._load_results_chunks(dataset_id, stn_ids)

--- a/tethysts/tests/test_tethysts.py
+++ b/tethysts/tests/test_tethysts.py
@@ -142,7 +142,7 @@ def test_get_nearest_results2():
     assert len(s2) > 1
 
 
-def test_get_intersection_results1():
-    s3 = t1.get_results(dataset_id, lat=lat, lon=lon, distance=distance)
-
-    assert len(s3) > 1
+# def test_get_intersection_results1():
+#     s3 = t1.get_results(dataset_id, lat=lat, lon=lon, distance=distance)
+#
+#     assert len(s3) > 1

--- a/tethysts/tests/utest_tethysts.py
+++ b/tethysts/tests/utest_tethysts.py
@@ -30,7 +30,7 @@ remotes_list = param['remotes']
 remote = {'bucket': 'fire-emergency-nz', 'connection_config': 'https://b2.tethys-ts.xyz', 'version': 2}
 remote = {'bucket': 'es-hilltop', 'connection_config': 'https://b2.tethys-ts.xyz'}
 remote = {'bucket': 'niwa-cliflo', 'connection_config': 'https://b2.tethys-ts.xyz'}
-remote = {'bucket': 'ecan-env-monitoring', 'connection_config': 'https://b2.tethys-ts.xyz', 'version': 2}
+remote = {'bucket': 'ecan-env-monitoring', 'public_url': 'https://b2.tethys-ts.xyz/file', 'version': 2}
 remote = {'bucket': 'point-forecasts', 'connection_config': 'https://b2.tethys-ts.xyz', 'version': 3}
 remote = {'bucket': 'met-solutions', 'connection_config': 'https://b2.tethys-ts.xyz', 'version': 3}
 # remote = {'bucket': 'nasa-data', 'connection_config': 'https://b2.tethys-ts.xyz'}
@@ -155,7 +155,7 @@ geom_query = shape(query_geometry).buffer(0.1)
 
 stn_list2 = self.get_stations(dataset_id, query_geometry)
 stn_list2 = self.get_stations(dataset_id, lat=-43.1, lon=171.1)
-data2 = self.get_results(dataset_id, geometry=query_geometry, squeeze_dims=True, output='Dataset')
+data2 = self.get_results(dataset_id, geometry=query_geometry, output='Dataset')
 
 stn = [s for s in stn_list1 if s['station_id'] == station_id]
 
@@ -205,12 +205,12 @@ sdf2['y'] = sdf2.geometry.y.round(1)
 geometry: dict = None
 lat: float = None
 lon: float = None
-from_date: Union[str, pd.Timestamp, datetime] = None
-to_date: Union[str, pd.Timestamp, datetime] = None
-from_mod_date: Union[str, pd.Timestamp, datetime] = None
-to_mod_date: Union[str, pd.Timestamp, datetime] = None
-version_date: Union[str, pd.Timestamp, datetime] = None
-heights: Union[int, float] = None
+from_date = None
+to_date = None
+from_mod_date = None
+to_mod_date = None
+version_date = None
+heights = None
 bands: int = None
 squeeze_dims: bool = False
 output: str = 'Dataset'
@@ -220,6 +220,9 @@ remote = {'bucket': 'typhon', 'public_url': 'https://b2.tethys-ts.xyz/file/', 'v
 remote = {'bucket': 'nz-open-modelling-consortium', 'public_url': 'https://b2.nzrivers.xyz/file/', 'version': 4}
 remote = {'bucket': 'fire-emergency-nz', 'public_url': 'https://b2.tethys-ts.xyz/file/', 'version': 4}
 remote = {'bucket': 'fire-emergency-nz', 'public_url': 'https://b2.tethys-ts.xyz/file/', 'version': 2}
+remote = {'bucket': 'nasa-data', 'public_url': 'https://b2.tethys-ts.xyz/file/', 'version': 4}
+remote = {'bucket': 'point-forecasts', 'public_url': 'https://b2.tethys-ts.xyz/file', 'version': 4}
+remote = {'bucket': 'ecan-env-monitoring', 'public_url': 'https://b2.tethys-ts.xyz/file', 'version': 4}
 
 cache = '/media/nvme1/cache/tethys'
 
@@ -240,6 +243,20 @@ ref = 'ashley'
 
 station_ids = 'c15ce95a56b39b6dfeea00e8'
 
+dataset_id = '0de7cbfe05aebc2272ceba17'
+
+dataset_id = 'f56892eb59d12cfbc02acceb'
+
+dataset_id = 'c3a09c8a5da175897916e8e8'
+
+dataset_id = '799329b9023c9d9980abd1f6'
+
+dataset_id = '8d4afa6c8e82d91b81879c12'
+
+dataset_id = 'c3a09c8a5da175897916e8e8'
+
+dataset_id = '63a6144a796c05fc67813d46'
+
 self = Tethys([remote], cache=cache)
 self = Tethys([remote])
 self = Tethys()
@@ -247,7 +264,7 @@ self = Tethys()
 rv1 = self.get_versions(dataset_id)
 stns1 = self.get_stations(dataset_id)
 
-station_ids = [s['station_id'] for s in stns1[:3]]
+station_ids = [s['station_id'] for s in stns1[:1]]
 station_ids = [s['station_id'] for s in stns1 if ref in s['ref']]
 
 results1 = self.get_results(dataset_id, station_ids, heights=None)
@@ -335,7 +352,7 @@ ds_id = 'c5f55d97e71e7cd73295ad7f'
 stn = [s for s in stns if s['station_id'] == '751946ea52d04e67639fea1c'][0]
 stn0 = [s for s in stns0 if s['station_id'] == '17c7c90057683b807ad77b10'][0]
 
-[s for s in stns if 'poroporo' in s['ref']]
+[s for s in stns1 if 'Waimak' in s['name']]
 
 [s for s in stns0 if 'poroporo' in s['ref']]
 

--- a/tethysts/utils.py
+++ b/tethysts/utils.py
@@ -202,7 +202,7 @@ def get_nearest_from_extent(data,
         lons = data['lon'].values
         xy = cartesian_product(lons, lats)
         kdtree = spatial.cKDTree(xy)
-        dist, index = kdtree.query(np.array(geom_query.coords))
+        dist, index = kdtree.query(geom_query.coords[0])
         lon_n, lat_n = xy[index]
 
     data1 = data.sel(lon=[lon_n], lat=[lat_n])
@@ -505,7 +505,7 @@ def convert_results_v2_to_v3(data):
     geo1 = Point(float(data['lon']), float(data['lat'])).wkb_hex
     data2 = data.assign_coords({'geometry': geo1})
     if 'virtual_station' in data2:
-        data2 = data2.drop('virtual_station')
+        data2 = data2.drop_vars('virtual_station')
 
     # data2['station_id'].attrs = data['station_id'].attrs
     data2['geometry'].attrs = {'long_name': 'The hexadecimal encoding of the Well-Known Binary (WKB) geometry', 'crs_EPSG': 4326}
@@ -743,7 +743,7 @@ def load_dataset(results, from_date=None, to_date=None):
         data = results
 
     chunk_vars = [v for v in list(data.variables) if ('chunk' in v)]
-    data = data.drop(chunk_vars)
+    data = data.drop_vars(chunk_vars)
 
     if isinstance(from_date, (str, pd.Timestamp, datetime)):
         from_date1 = pd.Timestamp(from_date)

--- a/tethysts/utils.py
+++ b/tethysts/utils.py
@@ -202,7 +202,7 @@ def get_nearest_from_extent(data,
         lons = data['lon'].values
         xy = cartesian_product(lons, lats)
         kdtree = spatial.cKDTree(xy)
-        dist, index = kdtree.query(np.array(geom_query))
+        dist, index = kdtree.query(np.array(geom_query.coords))
         lon_n, lat_n = xy[index]
 
     data1 = data.sel(lon=[lon_n], lat=[lat_n])


### PR DESCRIPTION
The get_results method only does a nearest neighbor query rather than all the other spatial queries that the get_stations method does. The get_stations method should be the route to take to find the appropriate stations then pass those stations to the get_results method.